### PR TITLE
Versión 1.5

### DIFF
--- a/IECE_WebApi/Controllers/Integrante_Comision_DistritalController.cs
+++ b/IECE_WebApi/Controllers/Integrante_Comision_DistritalController.cs
@@ -85,10 +85,11 @@ namespace IECE_WebApi.Controllers
         }
 
         // POST: api/Integrante_Comision_Distrital
-        [HttpPost]
+        
         [Route("[action]")]
+        [HttpPost]
         [EnableCors("AllowOrigin")]
-        public IActionResult PostIntegrante_Comision_Distrital(Integrante_Comision_Distrital integrante_Comision_Distrital)
+        public IActionResult PostIntegrante_Comision_Distrital([FromBody]Integrante_Comision_Distrital integrante_Comision_Distrital)
         {
             Integrante_Comision_Distrital NuevoIntegrante = integrante_Comision_Distrital;
 

--- a/IECE_WebApi/Controllers/Integrante_Comision_LocalController.cs
+++ b/IECE_WebApi/Controllers/Integrante_Comision_LocalController.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore;
 using IECE_WebApi.Contexts;
 using IECE_WebApi.Models;
 using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 namespace IECE_WebApi.Controllers
 {
@@ -96,7 +98,7 @@ namespace IECE_WebApi.Controllers
         [HttpPost]
         [Route("[action]")]
         [EnableCors("AllowOrigin")]
-        public IActionResult PostIntegrante_Comision_Local(Integrante_Comision_Local integrante_Comision_Local)
+        public IActionResult PostIntegrante_Comision_Local([FromBody]Integrante_Comision_Local integrante_Comision_Local)
         {
             Integrante_Comision_Local NuevoIntegrante = integrante_Comision_Local;
 
@@ -140,10 +142,6 @@ namespace IECE_WebApi.Controllers
                     mensaje = ex.Message
                 });
             }
-
-
-
-
         }
 
         // DELETE: api/Integrante_Comision_Local/5

--- a/IECE_WebApi/Controllers/PersonalMinisterialController.cs
+++ b/IECE_WebApi/Controllers/PersonalMinisterialController.cs
@@ -504,7 +504,7 @@ namespace IECE_WebApi.Controllers
             {
                 List<Distrito> distritos = new List<Distrito>();
                 var d1 = (from d in context.Distrito
-                             where d.pem_Id_Obispo == idMinistro
+                             where d.pem_Id_Obispo == idMinistro && d.dis_Activo==true
                              select d).ToList();
 
                 var d2 = (from s in context.Sector
@@ -982,7 +982,7 @@ namespace IECE_WebApi.Controllers
                 PersonalAdministrativo pastor = new PersonalAdministrativo();
                 Personal_Ministerial pastor1 = (from pm in context.Personal_Ministerial
                                                     join s in context.Sector on pm.pem_Id_Ministro equals s.pem_Id_Pastor
-                                                    where pm.sec_Id_Congregacion == sec_Id_Sector
+                                                    where s.sec_Id_Sector == sec_Id_Sector
                                                     && pm.pem_Activo
                                                     select pm).FirstOrDefault();
 

--- a/IECE_WebApi/Controllers/SendMailController.cs
+++ b/IECE_WebApi/Controllers/SendMailController.cs
@@ -57,7 +57,7 @@ namespace IECE_WebApi.Controllers
         string EMAILPASSWORD = global.passEmail;
         string SMTPSERVER = global.smtpEmail;
         int PUERTO = 587;
-        bool ENCRIPTACION = false;
+        bool ENCRIPTACION = true;
         bool FORMATO = true;
 
         // POST api/<controller>
@@ -273,7 +273,7 @@ namespace IECE_WebApi.Controllers
                 message.Subject = objeto.asunto;
                 message.IsBodyHtml = FORMATO;
                 message.Body = objeto.mensaje;
-                smtp.Send(message);
+                 smtp.Send(message);
                 return Ok(
                     new
                     {
@@ -353,7 +353,7 @@ namespace IECE_WebApi.Controllers
             {
                 return Ok(new
                 {
-                    status = "errro",
+                    status = "error",
                     mensaje = ex.Message
                 });
             }

--- a/IECE_WebApi/Models/Integrante_Comision_Local.cs
+++ b/IECE_WebApi/Models/Integrante_Comision_Local.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 


### PR DESCRIPTION
1.-Se corrigió un error en los controladores de Integrantes_Comision_Local e Integrantes_Comision_Distrital. 2.- Se corrigió error en Controlador Personal Ministerial para que en Login muestre solo los Distritos activos en los que el ministro es el Obispo. Y para que en el Reporte de Administración se mostrara correctamente el Pastor de cada Sector. 3.- Se actualizó controlador de SendMail, una vez que se compró el Certificado https para el Correo iece.mx, cmabiando el valor de ENCRIPTATION=True.